### PR TITLE
Catch broken JSON on _handleResponse

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -265,7 +265,14 @@ class Client extends EventEmitter {
      * @private
      */
     _handleResponse(buffer) {
-        const message = JSON.parse(buffer + '');
+        let message;
+        try {
+            message = JSON.parse(buffer + '');
+        } catch (e) {
+            console.error('Can not parse JSON:', e);
+            return;
+        }
+
         this._trace('IN.MSG', message);
 
         // Extract encrypted package from message using device key (if available)


### PR DESCRIPTION
From time to time I'm getting error reports from the users that JSON.parse caused crash:

```
Crash report:
    undefined:1
MO_I 
^

SyntaxError: Unexpected token M in JSON at position 0
    at JSON.parse (<anonymous>)
    at Client._handleResponse (/node_modules/gree-hvac-client/lib/client.js:268:30)
    at Socket._socket.on.message (/node_modules/gree-hvac-client/lib/client.js:110:52)
    at emitTwo (events.js:126:13)
    at Socket.emit (events.js:214:7)
    at UDP.onMessage [as onmessage] (dgram.js:659:8)
```

This fix should prevent app crashes