### PR TITLE
Clear intervals for socket timeout and status timeout on disconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,6 +128,12 @@ class Client extends EventEmitter {
         if (this._statusIntervalRef) {
             clearInterval(this._statusIntervalRef);
         }
+        if (this._socketTimeoutRef) {
+            clearTimeout(this._socketTimeoutRef);
+        }
+        if (this._statusTimeoutRef) {
+            clearTimeout(this._statusTimeoutRef);
+        }
         this._socket.close();
         this.emit('disconnect');
     }


### PR DESCRIPTION
to prevent "Error [ERR_SOCKET_DGRAM_NOT_RUNNING]: Not running" error