### PR TITLE
Remove os restrictions from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
   "engines": {
     "node": ">=8.11.0"
   },
-  "os": [
-    "darwin",
-    "linux"
-  ],
   "devDependencies": {
     "jsdoc-to-markdown": "^5.0.0",
     "mocha": "^6.2.0"


### PR DESCRIPTION
`package.json` contains restriction on the OS.
I don't see any *nix-related logic in the library, so I believe we can remove this restrictions

close #8 