### PR TITLE
Add TemSen property to receive current room temperature

### DIFF
--- a/lib/property-transformer.js
+++ b/lib/property-transformer.js
@@ -20,6 +20,19 @@ const PROPERTY_VENDOR_CODES = {
     powerSave: 'SvSt',
 };
 
+const PROPERTY_OPTIONS = {
+    currentTemperature: {
+        readOnly: true,
+        fromVendorTransformer: function (value) {
+            // Temperature from the AC should be transformed by subtract 40 to get real temperature
+            // AC returns temperature+40. I believe it's because it has unsigned data type
+            // When TemSen=0 it means real temperature is -40 degrees
+            // @see https://github.com/ddenisyuk/homebridge-gree-heatercooler/blob/3979fc6dad9d1935c59c686eb1764a062246ee7c/index.js#L224-L226
+            return value - 40;
+        },
+    }
+}
+
 /**
  * Transforms device properties from vendor names to human friendly names and back
  * @private
@@ -53,7 +66,10 @@ class PropertyTransformer {
         let ret = {};
         for (let [property, value] of Object.entries(properties)) {
             const reversedProperty = this._reversedProperties[property];
-            ret[reversedProperty] = this._reversedValues[reversedProperty][value] || value;
+            const transformValue = PROPERTY_OPTIONS[reversedProperty]
+                && PROPERTY_OPTIONS[reversedProperty].fromVendorTransformer || (v => v);
+            const reversedValue = this._reversedValues[reversedProperty][value] || value;
+            ret[reversedProperty] = transformValue(reversedValue);
         }
         return ret;
     }
@@ -66,6 +82,10 @@ class PropertyTransformer {
     toVendor(properties) {
         let ret = {};
         for (let [property, value] of Object.entries(properties)) {
+            const propertyOptions = PROPERTY_OPTIONS[property] || {};
+            if (propertyOptions.readOnly) {
+                throw new Error(`Cannot set read-only property ${property}`)
+            }
             const vendorProperty = this._properties[property];
             const values = this._values[property] || {};
             ret[vendorProperty] = values[value] !== undefined ? values[value] : value;

--- a/lib/property-transformer.js
+++ b/lib/property-transformer.js
@@ -6,6 +6,7 @@ const PROPERTY_VENDOR_CODES = {
     mode: 'Mod',
     temperatureUnit: 'TemUn',
     temperature: 'SetTem',
+    currentTemperature: 'TemSen',
     fanSpeed: 'WdSpd',
     air: 'Air',
     blow: 'Blo',

--- a/lib/property-value.js
+++ b/lib/property-value.js
@@ -76,6 +76,7 @@ const PROPERTY_VALUE = {
         fahrenheit: 'fahrenheit'
     },
     temperature: {},
+    currentTemperature: {},
     fanSpeed: {
         auto: 'auto',
         low: 'low',

--- a/lib/property-vendor-value.js
+++ b/lib/property-vendor-value.js
@@ -77,6 +77,7 @@ const PROPERTY_VALUE = {
         fahrenheit: 1
     },
     temperature: {},
+    currentTemperature: {},
     fanSpeed: {
         auto: 0,
         low: 1,

--- a/lib/property.js
+++ b/lib/property.js
@@ -8,6 +8,7 @@
  * @property {string} mode - Mode of operation
  * @property {string} temperatureUnit - Temperature unit (must be together with set temperature)
  * @property {string} temperature - Set temperature (must be together with temperature unit)
+ * @property {string} currentTemperature - Get current temperature from the internal (?) sensor (This value can not be set, only received)
  * @property {string} fanSpeed - Fan speed
  * @property {string} air - Fresh air valve
  * @property {string} blow - Keeps the fan running for a while after shutting down (also called "X-Fan", only usable in Dry and Cool mode)
@@ -25,6 +26,7 @@ const PROPERTY = {
     mode: 'mode',
     temperatureUnit: 'temperatureUnit',
     temperature: 'temperature',
+    currentTemperature: 'currentTemperature',
     fanSpeed: 'fanSpeed',
     air: 'air',
     blow: 'blow',

--- a/test/property-transformer-test.js
+++ b/test/property-transformer-test.js
@@ -8,7 +8,7 @@ describe('PropertyTransformer', function () {
             const result = SUT.fromVendor({
                 Mod: 1,
                 SetTem: 25,
-                TemSen: 27,
+                TemSen: 67,
             });
 
             assert.deepEqual(result, {
@@ -29,6 +29,17 @@ describe('PropertyTransformer', function () {
             assert.deepEqual(result, {
                 Mod: 1,
                 SetTem: 25
+            });
+        });
+        it('should not allow to change read-only property', function () {
+            const SUT = new PropertyTransformer();
+            assert.throws(() => {
+                SUT.toVendor({
+                    currentTemperature: 30
+                })
+            }, {
+                name: 'Error',
+                message: 'Cannot set read-only property currentTemperature'
             });
         });
     });

--- a/test/property-transformer-test.js
+++ b/test/property-transformer-test.js
@@ -7,12 +7,14 @@ describe('PropertyTransformer', function () {
             const SUT = new PropertyTransformer();
             const result = SUT.fromVendor({
                 Mod: 1,
-                SetTem: 25
+                SetTem: 25,
+                TemSen: 27,
             });
 
             assert.deepEqual(result, {
                 mode: 'cool',
-                temperature: 25
+                temperature: 25,
+                currentTemperature: 27
             });
         });
     });


### PR DESCRIPTION
I've found that HVAC returns the info of the current temperature. Seems it has internal sensor.
Room temperature is received using `TemSen` property and the value has offset of `+40`.
I believe it's because they are using unsigned data type.

The same approach is used in https://github.com/ddenisyuk/homebridge-gree-heatercooler/blob/3979fc6dad9d1935c59c686eb1764a062246ee7c/index.js#L224-L226

This PR was verified in https://github.com/aivus/com.gree

```
{
  t: 'dat',
  mac: 'ffffffffffff',
  r: 200,
  cols: [
    'Pow',    'Mod',
    'TemUn',  'SetTem',
    'TemSen', 'WdSpd',
    'Air',    'Blo',
    'Health', 'SwhSlp',
    'Lig',    'SwingLfRig',
    'SwUpDn', 'Quiet',
    'Tur',    'SvSt'
  ],
  dat: [
    0, 1, 0, 24, 65, 1,
    0, 0, 0,  0,  1, 0,
    6, 0, 0,  0
  ]
}
```

Also I've added `readOnly` option to this property to prevent set requests to HVAC.