### PR TITLE
Properly handle a case with missed val array in response

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -380,8 +380,8 @@ class Client extends EventEmitter {
     _handleUpdateConfirmResponse(pack) {
         let updatedProperties = {};
         pack.opt.forEach((opt, i) => {
-            updatedProperties[opt] = pack.val[i];
-            this._properties[opt] = pack.val[i];
+            const value = 'val' in pack ? pack.val : pack.p;
+            this._properties[opt] = updatedProperties[opt] = value[i];
         });
 
         this.emit(


### PR DESCRIPTION
Some firmwares are respond with only `p` option.

Example:
`{ t: 'res', mac: '502cc66e2155', r: 200, opt: [ 'SetTem' ], p: [ 21 ] }`

See https://github.com/tomikaa87/gree-remote/pull/42